### PR TITLE
Add null check for rules in styles function

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -40,10 +40,12 @@
     var sheets = document.styleSheets;
     for (var i = 0; i < sheets.length; i++) {
       var rules = sheets[i].cssRules;
-      for (var j = 0; j < rules.length; j++) {
-        var rule = rules[j];
-        if (typeof(rule.style) != "undefined") {
-          css += rule.selectorText + " { " + rule.style.cssText + " }\n";
+      if (rules != null) {
+        for (var j = 0; j < rules.length; j++) {
+          var rule = rules[j];
+          if (typeof(rule.style) != "undefined") {
+            css += rule.selectorText + " { " + rule.style.cssText + " }\n";
+          }
         }
       }
     }


### PR DESCRIPTION
I had an issue similar to #7. When trying to save a Google Chart, I encountered the same error "Cannot read property 'length' of null", also in Chrome. Added a null check to prevent this from occurring.
