### PR TITLE
Add functionality to convert <g> tags

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -72,6 +72,17 @@
     }
     return css;
   }
+  
+  function doG(el, options) {
+    var clone = el.cloneNode(true);
+    clone.removeAttribute('transform')
+	
+    var svg = document.createElementNS('http://www.w3.org/2000/svg','svg')
+    svg.setAttribute('width', options.g.width)
+    svg.setAttribute('height', options.g.height)
+    svg.appendChild(clone)
+    return svg;
+  }
 
   out$.svgAsDataUri = function(el, options, cb) {
     options = options || {};
@@ -79,7 +90,9 @@
 
     inlineImages(el, function() {
       var outer = document.createElement("div");
-      var clone = el.cloneNode(true);
+      var clone = options.g ?
+        doG(el, options) :
+        el.cloneNode(true);
       var width = parseInt(
         clone.getAttribute('width')
           || clone.style.width


### PR DESCRIPTION
This addition allows `<g>`'s to be converted to png. I just used height and width, not a viewbox.

``` javascript
saveSvgAsPng(gElement, "name.png", {g: {height: h, width: w}})
```

will grab gElement out of an SVG, remove its transform, wrap it in an `<svg>` tag with height = h, and width = w;

I'm using it in a private repository, but I can make a new example if you want to see it in action.
