### PR TITLE
remove javascript-created a tag after javascript-clicked

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -143,6 +143,9 @@
         a.download = name;
         a.href = canvas.toDataURL('image/png');
         document.body.appendChild(a);
+        a.addEventListener("click", function(e) {
+          a.parentNode.removeChild(a);
+        });
         a.click();
       }
     });


### PR DESCRIPTION
In my use case I might have to repeated hit a download PNG button, and didn't want to keep appending hidden `<a>` tags. This PR just has a callback to the javascript-click that deletes the tag.
