### PR TITLE
getComputetStyle must always be taken from window object

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -94,11 +94,11 @@
         width = parseInt(clone.getAttribute('width') ||
           box.width ||
           clone.style.width ||
-          out$.getComputedStyle(el).getPropertyValue('width'));
+          window.getComputedStyle(el).getPropertyValue('width'));
         height = parseInt(clone.getAttribute('height') ||
           box.height ||
           clone.style.height ||
-          out$.getComputedStyle(el).getPropertyValue('height'));
+          window.getComputedStyle(el).getPropertyValue('height'));
         if (width === undefined || 
             width === null || 
             isNaN(parseFloat(width))) {


### PR DESCRIPTION
When saveSvgAsPng gets loaded as module, then the out$ variable is set to the current object which of course does not contain the getComputedStyle function. So, this one must be taken from window. This probably happened during refactoring to support module loaders.
