### PR TITLE
Fix for issue 59 - an incompatibility with highcharts.

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -122,7 +122,7 @@
 
       clone.setAttribute("version", "1.1");
       
-      if (clone.getAttribute("xmlns") || clone.getAttributeNS(xmlnd, "xmlns")) {
+      if (clone.getAttribute("xmlns") || clone.getAttributeNS(xmlns, "xmlns")) {
         // if there's already a namespace attribute defined leave it as specified.
         
         // Having two xmlns attributes setting the data url on the image silently 

--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -122,13 +122,15 @@
 
       clone.setAttribute("version", "1.1");
       
-      // if there's already a non namespaced attribute for the svg namespace remove it.
-      // With having two xmlns attributes setting the data url on the image silently fails 
-      // with the onload never being called.
-      if (clone.getAttribute("xmlns") !== null) {
-        clone.removeAttribute("xmlns");
+      if (clone.getAttribute("xmlns") || clone.getAttributeNS(xmlnd, "xmlns")) {
+        // if there's already a namespace attribute defined leave it as specified.
+        
+        // Having two xmlns attributes setting the data url on the image silently 
+        // fails with the onload never being called - issue 59.
+      } else {
+        clone.setAttributeNS(xmlns, "xmlns", "http://www.w3.org/2000/svg");
       }
-      clone.setAttributeNS(xmlns, "xmlns", "http://www.w3.org/2000/svg");
+      
       clone.setAttributeNS(xmlns, "xmlns:xlink", "http://www.w3.org/1999/xlink");
       clone.setAttribute("width", width * options.scale);
       clone.setAttribute("height", height * options.scale);

--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -121,6 +121,13 @@
       }
 
       clone.setAttribute("version", "1.1");
+      
+      // if there's already a non namespaced attribute for the svg namespace remove it.
+      // With having two xmlns attributes setting the data url on the image silently fails 
+      // with the onload never being called.
+      if (clone.getAttribute("xmlns") !== null) {
+        clone.removeAttribute("xmlns");
+      }
       clone.setAttributeNS(xmlns, "xmlns", "http://www.w3.org/2000/svg");
       clone.setAttributeNS(xmlns, "xmlns:xlink", "http://www.w3.org/1999/xlink");
       clone.setAttribute("width", width * options.scale);


### PR DESCRIPTION
Added a test to see if there's already an xmlns attribute set on the cloned SVG node and if there is remove it so there's no conflict with the one we're adding, this is a fix for [issue 59](https://github.com/exupero/saveSvgAsPng/issues/59).
