### PR TITLE
Support requirejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ svgAsPngUri(document.getElementById("diagram"), {}, function(uri) {
 });
 ```
 
-Compatible with browserify.
+Compatible with [browserify](http://browserify.org/) and [requirejs](http://requirejs.org).
 
 ### Options
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Convert a browser SVG to PNG or dataUri",
   "main": "saveSvgAsPng.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,9 @@
   "bugs": {
     "url": "https://github.com/exupero/saveSvgAsPng/issues"
   },
-  "homepage": "https://github.com/exupero/saveSvgAsPng"
+  "homepage": "https://github.com/exupero/saveSvgAsPng",
+  "devDependencies": {
+    "requirejs": "^2.1.22",
+    "tape": "^4.2.2"
+  }
 }

--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -1,5 +1,5 @@
 (function() {
-  var out$ = typeof exports != 'undefined' && exports || this;
+  var out$ = typeof exports != 'undefined' && exports || typeof define != 'undefined' && {} || this;
 
   var doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
@@ -183,4 +183,12 @@
       a.click();
     });
   }
+
+  // if define is defined create as an AMD module
+  if (typeof define !== 'undefined') {
+    define(function() {
+      return out$;
+    });
+  }
+  
 })();

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+var test = require('tape');
+
+test('Is loadable using requirejs', function (assert) {
+	var requirejs = require('requirejs');
+	requirejs(['./saveSvgAsPng'], function(saveSvgAsPng) {
+		assert.ok(saveSvgAsPng, 'Loads saveSvgAsPng module.');
+
+		var contract = {
+			'svgAsDataUri': 'function',
+			'svgAsPngUri': 'function',
+			'saveSvgAsPng': 'function',
+		};
+
+		for (var property in saveSvgAsPng) {
+			if (saveSvgAsPng.hasOwnProperty(property)) {
+				var expectedType = contract[property];
+				var message = 'Has ' + property + ' of type ' + expectedType;
+				assert.equals(typeof saveSvgAsPng[property], expectedType, message);	
+			}
+		}
+
+		assert.end();
+	});
+});


### PR DESCRIPTION
To test this functionality tape and requirejs were added as dev dependencies, and so the unit tests can now be ran via `npm test`
