### PR TITLE
Make catch ECMAScript compliant

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -172,9 +172,13 @@
         var a = document.createElement('a'), png;
         try {
           png = canvas.toDataURL('image/png');
-        } catch (e if e instanceof SecurityError) {
-          console.error("Rendered SVG images cannot be downloaded in this browser.");
-          return;
+        } catch (e) {
+          if (e instanceof SecurityError) {
+            console.error("Rendered SVG images cannot be downloaded in this browser.");
+            return;
+          } else {
+            throw e;
+          }
         }
         cb(png);
       }


### PR DESCRIPTION
The "catch (e if e instanceof ....)" handler utterly fails in nodejs because this syntax is not part of the ECMAScript specification.
