### PR TITLE
Add check for viewBox attribute to support jsdom

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -83,7 +83,7 @@
   }
 
   function getDimension(el, clone, dim) {
-    var v = (el.viewBox.baseVal && el.viewBox.baseVal[dim]) ||
+    var v = (el.viewBox && el.viewBox.baseVal && el.viewBox.baseVal[dim]) ||
       (clone.getAttribute(dim) !== null && !clone.getAttribute(dim).match(/%$/) && parseInt(clone.getAttribute(dim))) ||
       el.getBoundingClientRect()[dim] ||
       parseInt(clone.style[dim]) ||
@@ -206,5 +206,5 @@
       return out$;
     });
   }
-  
+
 })();


### PR DESCRIPTION
Hey hey,

I've been trying to use this library within a [jsdom](https://github.com/tmpvar/jsdom) environment. This PR fixes the only issue I've had with `saveSvgAsPng` so far: since `viewBox` isn't defined (I imagine jsdom's implementation of SVG elements isn't as complete as the browser's), it was crashing before.

If someone wants to do something similar in the future, here's an example: https://github.com/ThibWeb/chart-export-example/blob/master/jsdom.js.
