### PR TITLE
allow font cleaning and remapping for SVG output

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
     src: url(stalemate.ttf) format('truetype');
   }
 
+  #illustrator-font text {
+    font-family: 'Georgia';
+  }
+
   input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button {
     padding: 15px;
   }
@@ -258,6 +262,14 @@
         <text x=100 y=100 text-anchor=middle dy=14 style="font-family:'Stalemate';font-size:36pt;">Custom Fonts</text>
       </svg>
     </li>
+
+    <li id=illustrator-font>
+      <svg width=200 height=200>
+        <text x=100 y=100 text-anchor=middle dy=14 style="font-size:36pt;">Illustrator Fonts</text>
+      </svg>
+      <button id="illustrator-btn" class="save btn">Save as SVG</button>
+    </li>
+
   </ul>
 </div>
 
@@ -332,6 +344,24 @@
   inlineTest('With foreign objects', $('#foreign-object'));
   inlineTest('With opacity', $('#opacity'));
   inlineTest('With custom fonts', $('#custom-font'));
+
+  $('#illustrator-btn').on('click', function() {
+    console.log('clicked')
+    svgAsDataUri($('#illustrator-font svg')[0], {
+      cleanFontDefs: true,
+      fontFamilyRemap: { "Georgia": "Arial"}
+    }, function(uri) {
+      console.log(uri)
+      var a = document.createElement('a');
+      a.download = 'test.svg';
+      a.href = uri;
+      document.body.appendChild(a);
+      a.addEventListener("click", function(e) {
+        a.parentNode.removeChild(a);
+      });
+      a.click();
+    });
+  });
 
   var $sandbox = $('#sandbox');
   $sandbox.find('.render').click(function() {

--- a/index.html
+++ b/index.html
@@ -346,12 +346,10 @@
   inlineTest('With custom fonts', $('#custom-font'));
 
   $('#illustrator-btn').on('click', function() {
-    console.log('clicked')
     svgAsDataUri($('#illustrator-font svg')[0], {
       cleanFontDefs: true,
       fontFamilyRemap: { "Georgia": "Arial"}
     }, function(uri) {
-      console.log(uri)
       var a = document.createElement('a');
       a.download = 'test.svg';
       a.href = uri;


### PR DESCRIPTION
Hello. We are using saveSvgAsPng to make charts and export them as SVG, so that they can be hand-edited in Illustrator. There is a terrible issue with some versions of Illustrator where it gives a cryptic error if you have a font declaration with either 1) more than one font or 2) a font that is not on your system or named incorrectly.

This change adds two options to the library:
1. `cleanFontDefs`, a boolean that if `true` will extract only the first font-family definition
2. `fontFamilyRemap`, an optional hash that remaps the font-family name of the extracted first definition. 

I have added an example to index.html that downloads an SVG declared as Georgia, but when you open in illustrator, it is set to Arial. The use case for this is when CSS fonts are declared using CSS conventions like `Khula-Light` while local fonts may show up as `Khula Light`, or when you can't assume people will have a custom font installed locally so you may want to remap it to `Arial` or something.

Let me know what you think, if you're good with this I can add docs on these options. Thanks
