### PR TITLE
Add reference to TypeScript type definitions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ svgAsPngUri(document.getElementById("diagram"), {}, function(uri) {
 
 Compatible with [browserify](http://browserify.org/) and [requirejs](http://requirejs.org).
 
+If you want to use TypeScript, necessary [type definitions](https://github.com/martianov/typed-save-svg-as-png) are available in [Typings](https://github.com/typings/typings) [public registry](https://github.com/typings/registry).
+
 ### Options
 
 - `backgroundColor` — Creates a PNG with the given background color. Defaults to transparent.


### PR DESCRIPTION
Eric,
I performed necessary actions to add saveSvgAsPng type definitions in Typings public registry. This pull-request adds reference to it in README (according your answer #86). I hope it may be helpful to anyone but me.
