### PR TITLE
Fix missing arg in processFontQueue

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -211,7 +211,7 @@
           console.warn('Failed to load font from: ' + font.url);
           console.warn(e)
           css += font.text + '\n';
-          processFontQueue();
+          processFontQueue(queue);
         }
 
         function updateFontStyle(font, fontInBase64) {


### PR DESCRIPTION
There's a missing argument in processFontQueue when font loading fails. I think this is the obvious fix.