### PR TITLE
Don't load fonts from URL "about:blank"

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -125,6 +125,11 @@
                 externalFontUrl = '';
               }
 
+              if (externalFontUrl === 'about:blank') {
+                // no point trying to load this
+                externalFontUrl = '';
+              }
+
               if (externalFontUrl) {
                 // okay, we are lucky. We can fetch this font later
 


### PR DESCRIPTION
[MathJax](https://www.mathjax.org/) has this CSS rule:

```css
@font-face {font-family: MathJax_Blank; src: url('about:blank')}
```

That leads saveSvgAsPng to try to fetch the font from `about:blank`, which is never going to work. I don't know if this is the only case that should be filtered out, but it cuts out a lot of warning messages for me.