### PR TITLE
Fix blurry output on HiDPI Screens with svgAsPngUri

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -371,6 +371,15 @@
       canvas.width = w;
       canvas.height = h;
 
+      var pixelRatio = window.devicePixelRatio || 1;
+
+      canvas.style.width = canvas.width +'px';
+      canvas.style.height = canvas.height +'px';
+      canvas.width *= pixelRatio;
+      canvas.height *= pixelRatio;
+
+      context.setTransform(pixelRatio,0,0,pixelRatio,0,0);
+      
       if(options.canvg) {
         options.canvg(canvas, src);
       } else {


### PR DESCRIPTION
As described (in both problem and solution) here: https://stackoverflow.com/questions/24395076/canvas-generated-by-canvg-is-blurry-on-retina-screen svgAsPngUri will provide blurry output on HiDPI screens.

This PR fixes the issue on Chrome 62.0.3202.62 x64, Win10 1709.