### PR TITLE
[tiny] prevent errors when svg element is an orphan

### DIFF
--- a/saveSvgAsPng.js
+++ b/saveSvgAsPng.js
@@ -96,7 +96,7 @@
 
             try {
               if (selectorText) {
-                match = el.querySelector(selectorText) || el.parentNode.querySelector(selectorText);
+                match = el.querySelector(selectorText) || (el.parentNode && el.parentNode.querySelector(selectorText));
               }
             } catch(err) {
               console.warn('Invalid CSS selector "' + selectorText + '"', err);


### PR DESCRIPTION
If you're trying to save an svg element which doesn't have a parent (for example, you've cloned an svg in the page to make some changes to it before conversion), you will currently receive a lot of stylesheet-based errors.

This PR fixes that by explicitly checking for the parent element before trying to call its `querySelector` method.