### PR TITLE
Update AMD module definition to not be anonymous

### DIFF
--- a/src/saveSvgAsPng.js
+++ b/src/saveSvgAsPng.js
@@ -1,6 +1,6 @@
 (function() {
   const out$ = typeof exports != 'undefined' && exports || typeof define != 'undefined' && {} || this || window;
-  if (typeof define !== 'undefined') define(() => out$);
+  if (typeof define !== 'undefined') define('save-svg-as-png', [], () => out$);
 
   const xmlns = 'http://www.w3.org/2000/xmlns/';
   const doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY nbsp "&#160;">]>';


### PR DESCRIPTION
[Older Ember versions don't support anonymous AMD modules](https://github.com/ember-cli/ember-cli/pull/5512), and unfortunately I'm stuck on an older Ember version for now and am not able to import this module due to that. This PR resolves the issue by naming the module definition and providing an empty dependency array, which AFAIK should not be a breaking change (but correct me if I'm wrong).