### PR TITLE
Fix foreignObject namespace setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
     <li id=xmlns-override>
       <svg width=200 height=200>
         <foreignobject x=50 y=50 width=50 height=100>
-          <div xml:xmlns="http://www.w3.org/2000/xmlns/">Foreign Object</div>
+          <div xmlns="http://www.w3.org/1999/xhtml">Foreign Object</div>
         </foreignobject>
       </svg>
     </li>

--- a/src/saveSvgAsPng.js
+++ b/src/saveSvgAsPng.js
@@ -3,7 +3,8 @@
   if (typeof define !== 'undefined') define('save-svg-as-png', [], () => out$);
   out$.default = out$;
 
-  const xhtmlNs = 'http://www.w3.org/2000/xmlns/';
+  const xmlNs = 'http://www.w3.org/2000/xmlns/';
+  const xhtmlNs = 'http://www.w3.org/1999/xhtml';
   const svgNs = 'http://www.w3.org/2000/svg';
   const doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY nbsp "&#160;">]>';
   const urlRegex = /url\(["']?(.+?)["']?\)/;
@@ -247,8 +248,8 @@
 
       clone.setAttribute('version', '1.1');
       clone.setAttribute('viewBox', [left, top, width, height].join(' '));
-      if (!clone.getAttribute('xmlns')) clone.setAttributeNS(xhtmlNs, 'xmlns', svgNs);
-      if (!clone.getAttribute('xmlns:xlink')) clone.setAttributeNS(xhtmlNs, 'xmlns:xlink', 'http://www.w3.org/1999/xlink');
+      if (!clone.getAttribute('xmlns')) clone.setAttributeNS(xmlNs, 'xmlns', svgNs);
+      if (!clone.getAttribute('xmlns:xlink')) clone.setAttributeNS(xmlNs, 'xmlns:xlink', 'http://www.w3.org/1999/xlink');
 
       if (responsive) {
         clone.removeAttribute('width');
@@ -260,10 +261,7 @@
       }
 
       Array.from(clone.querySelectorAll('foreignObject > *')).forEach(foreignObject => {
-        if (foreignObject.tagName === 'svg')
-          foreignObject.setAttributeNS(xhtmlNs, 'xmlns', svgNs);
-        else if (!foreignObject.getAttribute('xmlns'))
-          foreignObject.setAttributeNS(xhtmlNs, 'xmlns', xhtmlNs);
+        foreignObject.setAttributeNS(xmlNs, 'xmlns', foreignObject.tagName === 'svg' ? svgNs : xhtmlNs);
       });
 
       return inlineCss(el, options).then(css => {


### PR DESCRIPTION
The fix for #200 incorrectly changed the foreignObject namespace to XML's one instead of XHTML. This results in an invalid image.

This change addresses the issue. Namespace variable is also renamed to donate the actual value it is storing.